### PR TITLE
Updated Java to use always the latest java

### DIFF
--- a/.github/workflows/nativeimage.yaml
+++ b/.github/workflows/nativeimage.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: [ macos-latest ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17.0.6
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 17.0.6
+          java-version: '17'
           distribution: zulu
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -17,7 +17,7 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.2'
+          distribution: 'graalvm'
           java-version: '17'
           components: 'native-image'
 
@@ -42,10 +42,10 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17.0.6
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 17.0.6
+          java-version: '17'
           distribution: zulu
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.2'
+          distribution: 'graalvm'
           java-version: '17'
           components: 'native-image'
 
@@ -79,10 +79,10 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17.0.6
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 17.0.6
+          java-version: '17'
           distribution: zulu
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -91,7 +91,7 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.2'
+          distribution: 'graalvm'
           java-version: '17'
           components: 'native-image'
 


### PR DESCRIPTION
Updated the Setup JDK to use the latest version of Java always and Graalvm to use distribution instead of version. as recommended by https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later